### PR TITLE
Fix GitHub Actions workflow to not fail on code quality issues

### DIFF
--- a/.github/workflows/function-analysis.yml
+++ b/.github/workflows/function-analysis.yml
@@ -1,4 +1,4 @@
-name: Function Analysis
+name: Code Quality Check
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ on:
 
 jobs:
   analyze:
-    name: Analyze Code Quality
+    name: Check Code Quality
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -46,7 +46,8 @@ jobs:
             --format github \
             --output ci-results.json \
             --comment \
-            --verbose || echo "CI command failed with exit code $?"
+            --no-fail-on-violation \
+            --verbose
         env:
           GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
       


### PR DESCRIPTION
## Summary
- GitHub Actionsワークフローがコード品質の問題でエラーになる問題を修正
- `--no-fail-on-violation` フラグを追加して、品質問題を警告として扱うように変更

## Changes
- `.github/workflows/function-analysis.yml`: 
  - `--no-fail-on-violation` フラグを追加
  - ワークフロー名を "Code Quality Check" に変更
  - `|| echo` による失敗時処理を削除（不要になったため）

## Impact
- PRがコード品質問題でブロックされなくなります
- 品質問題は引き続きGitHub Annotationsで表示されます
- PRコメントで詳細な品質レポートが提供されます

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated CI workflow to prevent failures on code quality violations and improved reporting.
- **Tests**
	- Enhanced test coverage for command-line options and output formats, ensuring better CI integration.
- **Refactor**
	- Improved command-line option parsing and output handling for more reliable file and stdout/stderr separation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->